### PR TITLE
Realtime module

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -121,8 +121,14 @@ function formatKeys (module) {
     if (_.isArray(module.axes.x.key)) {
       dataItem.formatted_date_range =
         formatter.format(getRangeFromKeys(dataItem, module.axes.x.key), 'date');
+      dataItem.formatted_start_at = formatter.format(dataItem[module.axes.x.key[0]], 'date');
+      dataItem.formatted_end_at = formatter.format(dataItem[module.axes.x.key[1]], 'date');
     } else {
-      dataItem.formatted_date = formatter.format(dataItem[module.axes.x.key], 'date');
+      dataItem.formatted_start_at = formatter.format(dataItem[module.axes.x.key], 'date');
+
+      if (dataItem['_end_at']) {
+        dataItem.formatted_end_at = formatter.format(dataItem['_end_at'], 'date');
+      }
     }
   }
 

--- a/test/dashboard.spec.js
+++ b/test/dashboard.spec.js
@@ -191,7 +191,9 @@ describe('Dashboard', function () {
                 '_timestamp',
                 'end_at',
                 'formatted_date_range',
-                'formatted_change_from_previous'
+                'formatted_change_from_previous',
+                'formatted_end_at',
+                'formatted_start_at'
               ]
             );
           });
@@ -213,7 +215,9 @@ describe('Dashboard', function () {
                 'specific_data',
                 '_timestamp',
                 'end_at',
-                'formatted_date_range'
+                'formatted_date_range',
+                'formatted_end_at',
+                'formatted_start_at'
               ]
             );
           });
@@ -237,7 +241,9 @@ describe('Dashboard', function () {
                 'specific_data',
                 '_timestamp',
                 'end_at',
-                'formatted_date_range'
+                'formatted_date_range',
+                'formatted_end_at',
+                'formatted_start_at'
               ]
             );
           });
@@ -262,7 +268,9 @@ describe('Dashboard', function () {
               },
               formatted_date_range: '1 July 2013 to 30 June 2014',
               formatted_value: '1',
-              specific_data: 1
+              specific_data: 1,
+              formatted_end_at: '1 July 2014',
+              formatted_start_at: '1 July 2013'
             });
           });
       });


### PR DESCRIPTION
This gets the data for a realtime module.

It also adds the formatted start_at, end_at data back in for modules.

Reduce the size of the query to 2 to make the response faster. We only use the current value and the previous for the delta.

Our formatkeys data will only support 1 yaxis :(
