### PR TITLE
Do not format text as URLs

### DIFF
--- a/lib/utils/formatter.js
+++ b/lib/utils/formatter.js
@@ -197,10 +197,17 @@ var formatters = {
   },
 
   url: function (value) {
-    if (value.length === 0) {
-      return '';
+    var urlText = '';
+
+    if (value.length > 0) {
+      if (value.substring(0, 4) === 'http') {
+        urlText = '<a href="' + value + '">' + value.replace(/&/g, '&amp;') + '</a>';
+      } else {
+        urlText = value;
+      }
     }
-    return '<a href="' + value + '">' + value.replace(/&/g, '&amp;') + '</a>';
+
+    return urlText;
   }
 };
 

--- a/test/formatters.spec.js
+++ b/test/formatters.spec.js
@@ -540,6 +540,10 @@ describe('Formatter', function () {
       formatter.format('', 'url').should.equal('');
     });
 
+    it('does not attempt to format things that look like normal text', function () {
+      formatter.format('this is normal text', 'url').should.equal('this is normal text');
+    });
+
     it('formats a URL with query parameters', function () {
       formatter.format('http://example.com/?q=search&f=123', 'url')
         .should.equal('<a href="http://example.com/?q=search&f=123">' +


### PR DESCRIPTION
https://govuk.zendesk.com/tickets/906290

Previously, this formatter would attempt to format 'normal text' as a link, resulting in `<a href='normal text'>normal text</a>`.

This commit looks at the first 4 characters of the text to see whether the thing looks like a link before formatting it.