### PR TITLE
Reject the promise if it's not a user-satisfaction-score data-type

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -38,6 +38,8 @@ Module.prototype.resolve = function () {
     } else {
       if (this.moduleConfig['data-source']['data-type'] === 'user-satisfaction-score') {
         return this.getData();
+      } else {
+        return Q.reject(this.moduleConfig['module-type'] + ' - Module not supported');
       }
     }
   } else {


### PR DESCRIPTION
This is to ensure we only support user_satisfaction_graph that have been transformed.