### PR TITLE
Revert "Define a default User-Agent header"

### DIFF
--- a/lib/request-promise.js
+++ b/lib/request-promise.js
@@ -1,9 +1,6 @@
 var Q = require('q'),
   request = process.browser ? require('browser-request') : require('request'),
-  qs = require('qs'),
-  p = require('../package.json'),
-  userAgent = p['name'] + '/' + p['version'],
-  _ = require('lodash');
+  qs = require('qs');
 
 module.exports = function requestPromise (options, logger) {
   var deferred = Q.defer();
@@ -18,10 +15,6 @@ module.exports = function requestPromise (options, logger) {
 
   if (options.url) {
     log.info('Making a request to:', options.url);
-
-    options.headers = _.extend({
-      'user-agent': userAgent
-    }, options.headers);
 
     request(options, function (err, res, body) {
       if (err) {

--- a/test/request-promise.spec.js
+++ b/test/request-promise.spec.js
@@ -65,25 +65,6 @@ describe('Request-Promise', function () {
 
     requestOptions.should.eql({
       foo: 'bar',
-      headers: {
-        'user-agent': require('../package.json')['name'] + '/' +
-          require('../package.json')['version']
-      },
-      json: true,
-      url: 'http://baseurl.com/path'
-    });
-  });
-
-  it('should respect a user-agent override in the request', function () {
-    requestPromise({url: 'http://baseurl.com/path', foo: 'bar', json: true,
-      headers:{ 'user-agent':'Something else'}});
-    var requestOptions = stub.getCall(0).args[0];
-
-    requestOptions.should.eql({
-      foo: 'bar',
-      headers: {
-        'user-agent': 'Something else'
-      },
       json: true,
       url: 'http://baseurl.com/path'
     });


### PR DESCRIPTION
Reverts alphagov/performanceplatform-client.js#45

Because we have run anywhere code for the client browsers will moan if you try and set the user-agent.

See:

![screen shot 2015-03-12 at 12 20 37](https://cloud.githubusercontent.com/assets/92585/6617631/892545e6-c8b2-11e4-98e1-85deb2c6bce3.png)
