### PR TITLE
Use the correct axis.

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -111,24 +111,7 @@ function getModuleAxes (module) {
   }
 
   else if (type === 'user_satisfaction_graph') {
-    /* TODO: we currently remove the axes as that would give us the breakdown
-     * when we iterate over the axes. We don't currently want that in any of our
-     * use cases so we remove it here and point the the score.
-     */
-    return {
-      x: {
-        label: 'Time',
-        key: '_timestamp',
-        format: 'time'
-      },
-      y: [
-        {
-          label: 'User satisfaction',
-          key: 'score',
-          format: 'percent'
-        }
-      ]
-    };
+    return module.axes;
   }
 
   else if (type === 'grouped_timeseries') {

--- a/lib/views/Delta.js
+++ b/lib/views/Delta.js
@@ -27,6 +27,11 @@ Delta.prototype.createDeltas = function () {
     calculateDelta = true;
   }
 
+  if (this.moduleConfig['module-type'] !== 'grouped_timeseries') {
+    //For a delta we're only interested in the first axis for everything but grouped_timeseries
+    yAxes = [yAxes[0]];
+  }
+
   if (this.moduleConfig['data-source'] && this.moduleConfig['data-source']['query-params']) {
 
     if (this.moduleConfig['data-source']['query-params'].period) {
@@ -53,8 +58,6 @@ Delta.prototype.createDeltas = function () {
       }, this);
     }
   }
-
-
 
   _.each(yAxes, function (yAxis) {
     var valueAttr = yAxis.key || this.moduleConfig['value-attribute'];


### PR DESCRIPTION
For everything other than a grouped_timeseries we should just use the first item in the axes.

We need the axes for user sat for tables so I've re introduced that.