### PR TITLE
Bugfix for show-total-lines

### DIFF
--- a/lib/views/View.js
+++ b/lib/views/View.js
@@ -54,7 +54,7 @@ View.prototype.marshalData = function () {
           if (index === 0) {
             totals.push(_.clone(item));
           } else {
-            if (item[valueAttr]) {
+            if (item && item[valueAttr]) {
               totals[groupIndex][valueAttr] += item[valueAttr];
             }
           }


### PR DESCRIPTION
We have a few instances of people adding show-total-lines incorrectly in single-timeseries modules.

This is a belts and braces fix so that we don't try and get attributes on one dimensional data or null data.