### PR TITLE
Ensure the client doesn't fail on delta and percentOfTotal

### DIFF
--- a/lib/views/Table.js
+++ b/lib/views/Table.js
@@ -54,6 +54,11 @@ Table.prototype.tabularise = function () {
     var data = this.data;
     var valueAttr = yAxis.key || this.moduleConfig['value-attribute'];
 
+    if ((valueAttr.indexOf('delta(') !== -1) || valueAttr.indexOf('percentOfTotal(') !== -1) {
+      valueAttr = valueAttr.match(/((delta|percentOfTotal)\((.*?)\))/);
+      valueAttr = valueAttr[3];
+    }
+
     //sort the data if there is a sortby
     if (sortBy) {
       var sortOrder = this.moduleConfig['sort-order'] ?

--- a/lib/views/View.js
+++ b/lib/views/View.js
@@ -20,11 +20,12 @@ View.prototype.marshalData = function () {
 
   if (this.moduleConfig['data-source'] && this.moduleConfig['data-source']['query-params']) {
 
-    if (this.moduleConfig['data-source']['query-params'].period) {
+    if (this.moduleConfig['data-source']['query-params'].period && this.data) {
       this.reverseData = true;
     }
 
-    if (this.moduleConfig['data-source']['query-params'].group_by && yAxes.length > 1) {
+    if (this.moduleConfig['data-source']['query-params'].group_by &&
+      yAxes.length > 1 && yAxes[0].groupId) {
       _.each(this.moduleConfig['data-source']['query-params'].group_by, function (group, index) {
         if (group) {
           if (index === 0) {


### PR DESCRIPTION
An example follows:

```
 {
     "module-type": "table", 
     "axes": {
      "y": [
       {
        "format": "integer", 
        "key": "uniqueEvents:sum", 
        "label": "Volume last week"
       }, 
       {
        "format": "percent", 
        "key": "percentOfTotal(uniqueEvents:sum)", 
        "label": "Percentage of total help usage"
       }, 
       {
        "format": {
         "showSigns": true, 
         "type": "percent"
        }, 
        "key": "delta(uniqueEvents:sum)", 
        "label": "Change since previous week"
       }
      ], 
      "x": {
       "format": {
        "uppercase": [
         "dvsa"
        ], 
        "type": "sentence"
       }, 
       "key": "eventDetail", 
       "label": "Help usage"
      }
     }, 
     "modules": [], 
     "sort-order": "descending", 
     "sort-by": "uniqueEvents:sum", 
     "slug": "help-usage", 
     "data-source": {
      "data-group": "driving-test-practical-public", 
      "data-type": "journey-help", 
      "query-params": {
       "duration": 2, 
       "collect": [
        "uniqueEvents:sum"
       ], 
       "group_by": [
        "eventDetail"
       ], 
       "period": "week", 
       "filter_by": [
        "eventCategory:pp-book-practical-driving-test-public", 
        "eventType:help"
       ]
      }
     }
    }
```

Usually where we have a group_by we have a groupid mapping in the axes. For this type of table module we don't have one so this PR protects us from grouping where we have no groupid.

We also don't currently support delta() and percentOfTotal() in the axes so for this PR we remove them so we can render the data for big screen.

Issue #58 covers the delta and percentOfTotal issue although this may be a feature we add to the client in the future. It's still being discussed...