### PR TITLE
New option of formatDates

### DIFF
--- a/lib/views/Table.js
+++ b/lib/views/Table.js
@@ -13,7 +13,8 @@ Table.prototype.initialize = function (module, options) {
   View.prototype.initialize.call(this, module);
   this.options = _.extend({
     colsLimit: false,
-    rowsLimit: false
+    rowsLimit: false,
+    formatDates: true
   }, options);
   this.tabularise();
 };
@@ -87,10 +88,17 @@ Table.prototype.tabularise = function () {
       }
       //we only need the date column rendering once so do it before the first yAxis
       if (index === 0) {
-        if (xAxisKeyIsArray) {
-          xCol.push(formatter.format(getRangeFromKeys(item, this.axes.x.key), this.axes.x.format));
+        if (this.options.formatDates) {
+          if (xAxisKeyIsArray) {
+            xCol.push(formatter.format(
+              getRangeFromKeys(item, this.axes.x.key), this.axes.x.format)
+            );
+          } else {
+            xCol.push(formatter.format(item[this.axes.x.key], this.axes.x.format));
+          }
         } else {
-          xCol.push(formatter.format(item[this.axes.x.key], this.axes.x.format));
+          var xKey = _.isArray(this.axes.x.key) ? this.axes.x.key[0] : this.axes.x.key;
+          xCol.push(item[xKey]);
         }
       }
 

--- a/test/views/Table.spec.js
+++ b/test/views/Table.spec.js
@@ -101,6 +101,25 @@ describe('Table View', function () {
       ]);
     });
 
+    it('doesnt format the dates when the formatDates is set to false', function () {
+      table = new Table(_.cloneDeep(moduleData), {formatDates: false});
+
+      table.data.should.eql([
+        [
+          'Quarter',
+          '2013-07-01T00:00:00+00:00',
+          '2013-04-01T00:00:00+00:00',
+          '2013-01-01T00:00:00+00:00'
+        ],
+        [
+          'test',
+          1,
+          15,
+          2
+        ]
+      ]);
+    });
+
     describe('sorting data in tables', function () {
       var sortedTable;
       var sortedModuleData = _.cloneDeep(moduleData);


### PR DESCRIPTION
The table view by default assumes that we want pretty date formatting when we render a table.

For things such as a graphing library that might want dates in ISO we have a new option to leave dates alone.

This is just that with some tests.