### PR TITLE
Enable configuration of backdrop options across the app.

### DIFF
--- a/lib/Dashboard.js
+++ b/lib/Dashboard.js
@@ -9,14 +9,18 @@ function Dashboard (slug, options) {
   this.options =_.extend({
     json: true,
     slug: slug,
-    stagecraft: config.stagecraft,
-    backdrop: config.backdrop
+    stagecraft: {
+      url: config.stagecraft
+    },
+    backdrop: {
+      url: config.backdrop
+    }
   }, options);
 }
 
 Dashboard.prototype.getConfig = function () {
   var options = _.extend(this.options, {
-    url: this.options.stagecraft + 'public/dashboards?slug=' + this.options.slug
+    url: this.options.stagecraft.url + 'public/dashboards?slug=' + this.options.slug
   });
 
   return rp(options);

--- a/lib/Datasource.js
+++ b/lib/Datasource.js
@@ -6,15 +6,17 @@ var rp = require('./request-promise'),
 function Datasource (dataSourceConfig, options) {
   this.options =_.extend({
     json: true,
-    backdrop: config.backdrop
+    url: config.backdrop,
+    qs: {
+      flatten: true
+    }
   }, options);
 
   _.extend(this.options, {
-    url: this.options.backdrop + 'data/' +
+    url: this.options.url + 'data/' +
       dataSourceConfig['data-group'] + '/' + dataSourceConfig['data-type'],
-    qs: _.extend(dataSourceConfig['query-params'], {
-      flatten: true
-    }, (dataSourceConfig['query-params']['period']) ? {} :
+    qs: _.extend(dataSourceConfig['query-params'], this.options.qs,
+      (dataSourceConfig['query-params']['period']) ? {} :
       {'sort_by': '_timestamp:descending'} )
   });
 
@@ -47,7 +49,7 @@ function configureTimespans (queryParams) {
       PERIOD_TO_DURATION[queryParams.period];
   }
   if (!queryParams.period) {
-    queryParams.limit = 5;
+    queryParams.limit = queryParams.limit || 5;
   }
   _.each(['start_at', 'end_at'], function (prop) {
     if (queryParams[prop]) {

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -1,10 +1,15 @@
 var _ = require('lodash'),
   Datasource = require('./Datasource'),
-  Q = require('q');
+  Q = require('q'),
+  config = require('../config');
 
 function Module (moduleConfig, options) {
   this.moduleConfig = moduleConfig || {};
-  this.options = options || {};
+  this.options =_.extend({
+    backdrop: {
+      url: config.backdrop
+    }
+  }, options);
 
   if (this.isSupported(this.moduleConfig['module-type'])) {
     this.axes = getModuleAxes(this.moduleConfig);
@@ -26,7 +31,7 @@ Module.prototype.isSupported = function (moduleType) {
 };
 
 Module.prototype.getData = function () {
-  this.dataSource = new Datasource(this.moduleConfig['data-source'], this.options);
+  this.dataSource = new Datasource(this.moduleConfig['data-source'], this.options.backdrop);
   return this.dataSource.getData().then(_.bind(function (dataSource) {
     _.extend(this.dataSource, dataSource);
 

--- a/test/Dashboard.spec.js
+++ b/test/Dashboard.spec.js
@@ -131,8 +131,12 @@ describe('Dashboard', function () {
       dashboard.options.should.eql({
         json: true,
         slug: 'test-slug',
-        backdrop: 'https://www.performance.service.gov.uk/',
-        stagecraft: 'https://stagecraft.production.performance.service.gov.uk/'
+        backdrop: {
+          url: 'https://www.performance.service.gov.uk/'
+        },
+        stagecraft: {
+          url: 'https://stagecraft.production.performance.service.gov.uk/'
+        }
       });
     });
 
@@ -169,8 +173,12 @@ describe('Dashboard', function () {
               testSlug,
               json: true,
               slug: 'test-dashboard-slug',
-              backdrop: 'https://www.performance.service.gov.uk/',
-              stagecraft: 'https://stagecraft.production.performance.service.gov.uk/'
+              backdrop: {
+                url: 'https://www.performance.service.gov.uk/'
+              },
+              stagecraft: {
+                url: 'https://stagecraft.production.performance.service.gov.uk/'
+              }
             });
 
           dashboardConfig.should.equal(dashboardResponse);

--- a/test/Datasource.spec.js
+++ b/test/Datasource.spec.js
@@ -65,17 +65,16 @@ describe('Datasource', function () {
           limit: 5,
           sort_by: '_timestamp:descending'
         },
-        url: 'https://www.performance.service.gov.uk/data/transactional-services/summaries',
-        backdrop: 'https://www.performance.service.gov.uk/'
+        url: 'https://www.performance.service.gov.uk/data/transactional-services/summaries'
       });
     });
 
     it('allows optional options', function () {
       dataSource = new Datasource(dataSourceConfig, {
-        backdrop: 'test.com'
+        url: 'test.com/'
       });
 
-      dataSource.options.backdrop.should.equal('test.com');
+      dataSource.options.url.should.equal('test.com/data/transactional-services/summaries');
     });
 
     describe('querystring', function () {
@@ -109,6 +108,25 @@ describe('Datasource', function () {
         dataSource = new Datasource(dataSourceConfig);
 
         dataSource.options.qs.limit.should.equal(5);
+      });
+
+      it('change the limit if present', function () {
+        dataSourceConfig = {
+          'data-group': 'student-finance',
+          'data-type': 'site-traffic',
+          'query-params': {
+            'collect': ['users:sum'],
+            'group_by': 'dataType'
+          }
+        };
+
+        dataSource = new Datasource(dataSourceConfig, {
+          qs: {
+            limit: 2
+          }
+        });
+
+        dataSource.options.qs.limit.should.equal(2);
       });
 
     });


### PR DESCRIPTION
We can now set backdrop querystring data from the Dashboard level (resolve())

The datasource class will also listen to the configuration for a module instead of just defaulting to 5.

This allows us to have fuller data when we need it and limit it when we dont.